### PR TITLE
Affiche le nom de l'aide dans le fil d'Ariane

### DIFF
--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -14,6 +14,10 @@
         >
           <a v-bind:href="crumb.url ? crumb.url : '#'">{{ crumb.name }}</a>
         </li>
+
+        <li v-if="current_page_title" class="rf-breadcrumb__item rf-breadcrumb__item--current">
+            <a href="#">{{ current_page_title }}</a>
+        </li>
       </ul>
     </nav>
   </div>
@@ -26,6 +30,9 @@ export default {
     return {
       breadcrumbs: [],
     };
+  },
+  props: {
+      current_page_title: String,
   },
   created() {
     this.breadcrumbs = this.$route.meta.breadcrumbs;

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -8,7 +8,7 @@
         </li>
 
         <li
-          v-for="crumb in breadcrumbs"
+          v-for="crumb in breadcrumbs" :key="crumb.name"
           class="rf-breadcrumb__item"
           v-bind:class="{ 'rf-breadcrumb__item--current': !crumb.url }"
         >

--- a/src/router.js
+++ b/src/router.js
@@ -48,7 +48,6 @@ export default new Router({
       meta: {
         breadcrumbs: [
           { name: 'France Relance', url: '/' },
-          { name: 'Mon financement'},
         ]
       }
     },

--- a/src/views/AidDetail.vue
+++ b/src/views/AidDetail.vue
@@ -3,7 +3,7 @@
 
         <Header></Header>
 
-        <Breadcrumbs></Breadcrumbs>
+        <Breadcrumbs :current_page_title="title"></Breadcrumbs>
 
         <div class="rf-grid-row rf-grid-row--center">
 
@@ -24,7 +24,7 @@
 
                     <div class="conditions text-left my-5 pt-4 col-sm">
                         <h2 class="mb-4 fontBlack"><strong>Conditions</strong></h2>
-                        <div v-html="aide.eligibility" class=""></div> 
+                        <div v-html="aide.eligibility" class=""></div>
                     </div>
 
                     <div class="exemples text-left my-5 pt-4 col-sm">

--- a/src/views/AidDetail.vue
+++ b/src/views/AidDetail.vue
@@ -60,6 +60,7 @@
             return {
                 aide: null,
                 title: "",
+                meta_title: "",
                 description: "",
                 previewImg: require('@/assets/Preview.png'),
             }
@@ -70,14 +71,15 @@
             axios.get(`https://staging.aides-territoires.beta.gouv.fr/api/aids/${this.$route.params.slug}/`)
             .then(response => {
                  this.aide = response.data;
-                 this.title = response.data.short_title + " - Ministère de la Transformation et de la Fonction publiques";
+                 this.title = response.data.short_title;
+                 this.meta_title = this.title + " - Ministère de la Transformation et de la Fonction publiques"
                  this.description = response.data.name;
             })
         },
 
         metaInfo() {
           return {
-            title: this.title,
+            title: this.meta_title,
             meta: [
               {
                 name: "description",
@@ -85,7 +87,7 @@
               },
               {
                 property: 'og:title',
-                content: this.title
+                content: this.meta_title
               },
               {
                 property: 'og:description',
@@ -105,7 +107,7 @@
               },
               {
                 name: "twitter:title",
-                content: this.title
+                content: this.meta_title
               },
               {
                 name: "twitter:description",


### PR DESCRIPTION
Le nom de l'aide est affiché dans le fil d'Ariane.

Attention, les aides existantes ont souvent un champ « short_title » vide, ce qui fait que le fil reste vide.