### PR TITLE
Corrige un bug de lien non fonctionnel

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -50,7 +50,7 @@
           <div v-for="aide in aides" :key="aide.id" class="rf-col-xs-12 rf-col-sm-6  rf-col-md-4 rf-col-xl-3">
                 <router-link :to="{ name: 'aid_detail', params: { slug: aide.slug } }">
                   <div>
-                    <h3><a href="">{{ aide.name }}</a></h3>
+                    <h3>{{ aide.name }}</h3>
                     <div>
                       <p>Obtenir des informations</p>
                       <img src="@/assets/picto/Fleche.svg" alt="" />

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -48,15 +48,13 @@
          <div class="rf-grid-row rf-grid-row--gutter">
         <template v-slot:resultCards>
           <div v-for="aide in aides" :key="aide.id" class="rf-col-xs-12 rf-col-sm-6  rf-col-md-4 rf-col-xl-3">
-                <router-link :to="{ name: 'aid_detail', params: { slug: aide.slug } }">
-                  <div>
-                    <h3>{{ aide.name }}</h3>
-                    <div>
-                      <p>Obtenir des informations</p>
-                      <img src="@/assets/picto/Fleche.svg" alt="" />
-                    </div>
-                  </div>
-                </router-link>
+            <div>
+              <h3><router-link :to="{ name: 'aid_detail', params: { slug: aide.slug } }">{{ aide.name }}</router-link></h3>
+              <div>
+                <p>Obtenir des informations</p>
+                <img src="@/assets/picto/Fleche.svg" alt="" />
+              </div>
+            </div>      
           </div>
         </template>
         </div>


### PR DESCRIPTION
Les liens vers les aides ne fonctionnaient pas toujours, à cause de balises `a` imbriquées.