### PR TITLE
Corrige l'inclusion de matomo en dev

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,2 @@
 VUE_APP_API_ROOT='https://staging.aides-territoires.beta.gouv.fr'
 VUE_APP_MTFP_PARAM='505-mtfp'
-VUE_APP_USE_ANALYTICS=false
-VUE_APP_MATOMO_SITE_ID=42

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,3 @@
 VUE_APP_API_ROOT='https://aides-territoires.beta.gouv.fr'
 VUE_APP_MTFP_PARAM='662-mtfp'
-VUE_APP_USE_ANALYTICS=true
 VUE_APP_MATOMO_SITE_ID=139

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ Vue.config.productionTip = false
 
 Vue.use(VueMeta)
 
-if (process.env.VUE_APP_USE_ANALYTICS) {
+if (process.env.VUE_APP_MATOMO_SITE_ID) {
   Vue.use(VueMatomo, {
     host: 'https://stats.data.gouv.fr',
     siteId: process.env.VUE_APP_MATOMO_SITE_ID,


### PR DESCRIPTION
https://trello.com/c/WCb0QKFD/108-bug-matomo

Matomo était intégré en local, ce qui ne devrait pas être le cas.

En cause : les variables d'environnement sont toujours des chaînes, les valeurs booléennes ne sont pas parsées comme telles.