### PR TITLE
fix bug scroll behavior

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -57,5 +57,8 @@ export default new Router({
         ]
       }
     },
-  ]
+  ],
+  scrollBehavior (to, from, savedPosition) {
+    return { x: 0, y: 0 }
+  }
 })


### PR DESCRIPTION
Ajout de la fonction `scrollBehavior` dans le fichier router.js afin d'éviter le bug du scroll sur la page recherche en version mobile.