### PR TITLE
add publication_order parameter for api results

### DIFF
--- a/src/services/aidService.js
+++ b/src/services/aidService.js
@@ -10,7 +10,7 @@ export default {
 
     // Fetch a single aid object
     fetchAidDetail(slug) {
-        const url = 'aids/?order_by=publication_date' + slug + '/'
+        const url = 'aids/' + slug + '/'
         return api.get(url)
             .then(response => response.data);
     }

--- a/src/services/aidService.js
+++ b/src/services/aidService.js
@@ -4,13 +4,13 @@ export default {
     // Build an api call and fetch it's result
     fetchAidList(querystring) {
 
-        const params = `backers=${process.env.VUE_APP_MTFP_PARAM}&in_france_relance=true&${querystring}`;
+        const params = `backers=${process.env.VUE_APP_MTFP_PARAM}&in_france_relance=true&order_by=publication_date&${querystring}`;
         return api.get('/aids/?' + params);
     },
 
     // Fetch a single aid object
     fetchAidDetail(slug) {
-        const url = 'aids/' + slug + '/'
+        const url = 'aids/?order_by=publication_date' + slug + '/'
         return api.get(url)
             .then(response => response.data);
     }


### PR DESCRIPTION
Ajout du paramètre `order_by=publication_date` dans le fichier aidService.js afin de trier les résultats de recherche selon la date de publication. 