### PR TITLE
Corrige l'intégration de Matomo

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ if (process.env.VUE_APP_MATOMO_SITE_ID) {
   Vue.use(VueMatomo, {
     host: 'https://stats.data.gouv.fr',
     siteId: process.env.VUE_APP_MATOMO_SITE_ID,
+    router: router,
   });
 }
 


### PR DESCRIPTION
https://trello.com/c/OsxvAFi1/119-corrige-linclusion-de-matomo

Il manquait un paramètre à l'inclusion de Matomo, qui empêchait les changements de page d'être suivies dans les stats.